### PR TITLE
Interceptors

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -11,17 +13,20 @@ import (
 )
 
 func TestNewChatServer(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "NewChatServer() should not return error")
 	require.NotNil(t, server, "NewChatServer() should not return nil server")
 	assert.NotNil(t, server.validator, "NewChatServer() should create server with non-nil validator")
+	assert.NotNil(t, server.logger, "NewChatServer() should create server with non-nil logger")
 
 	// Test that the global validator is properly assigned
 	assert.Same(t, globalValidator, server.validator, "Server should use the global validator")
 }
 
 func TestChatServer_Say(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
 	tests := []struct {
@@ -86,7 +91,8 @@ func TestChatServer_Say(t *testing.T) {
 }
 
 func TestChatServer_Say_ContextCancellation(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
 	// Test with canceled context
@@ -103,7 +109,8 @@ func TestChatServer_Say_ContextCancellation(t *testing.T) {
 }
 
 func TestChatServer_Say_ContextTimeout(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
 	// Test with already timed out context
@@ -123,7 +130,8 @@ func TestChatServer_Say_ContextTimeout(t *testing.T) {
 }
 
 func TestChatServer_Say_RequestHeaders(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
 	req := connect.NewRequest(&chatv1.SayRequest{
@@ -143,7 +151,8 @@ func TestChatServer_Say_RequestHeaders(t *testing.T) {
 }
 
 func TestChatServer_Say_ResponseValidation(t *testing.T) {
-	server, err := NewChatServer()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
 	req := connect.NewRequest(&chatv1.SayRequest{

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
+	"io"
 	"log/slog"
-	"os"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -12,8 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
 func TestNewChatServer(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "NewChatServer() should not return error")
 	require.NotNil(t, server, "NewChatServer() should not return nil server")
@@ -25,7 +29,7 @@ func TestNewChatServer(t *testing.T) {
 }
 
 func TestChatServer_Say(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
@@ -91,7 +95,7 @@ func TestChatServer_Say(t *testing.T) {
 }
 
 func TestChatServer_Say_ContextCancellation(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
@@ -109,7 +113,7 @@ func TestChatServer_Say_ContextCancellation(t *testing.T) {
 }
 
 func TestChatServer_Say_ContextTimeout(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
@@ -130,7 +134,7 @@ func TestChatServer_Say_ContextTimeout(t *testing.T) {
 }
 
 func TestChatServer_Say_RequestHeaders(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 
@@ -151,7 +155,7 @@ func TestChatServer_Say_RequestHeaders(t *testing.T) {
 }
 
 func TestChatServer_Say_ResponseValidation(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newTestLogger()
 	server, err := NewChatServer(logger)
 	require.NoError(t, err, "Failed to create server")
 

--- a/internal/log.go
+++ b/internal/log.go
@@ -24,7 +24,7 @@ func (l *Logger) logStart(ctx context.Context, req connect.AnyRequest) {
 		ctx,
 		slog.LevelInfo,
 		"start processing request",
-		slog.String("produce", req.Spec().Procedure),
+slog.String("procedure", req.Spec().Procedure),
 		slog.String("user-agent", req.Header().Get("User-Agent")),
 		slog.String("http_method", req.HTTPMethod()),
 		slog.String("peer", req.Peer().Addr),

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"connectrpc.com/connect"
+)
+
+type Logger struct {
+	logger *slog.Logger
+}
+
+func NewLogger(logger *slog.Logger) *Logger {
+	return &Logger{
+		logger: logger,
+	}
+}
+
+func (l *Logger) logStart(ctx context.Context, req connect.AnyRequest) {
+	l.logger.LogAttrs(
+		ctx,
+		slog.LevelInfo,
+		"start processing request",
+		slog.String("produce", req.Spec().Procedure),
+		slog.String("user-agent", req.Header().Get("User-Agent")),
+		slog.String("http_method", req.HTTPMethod()),
+		slog.String("peer", req.Peer().Addr),
+	)
+}
+
+// logEnd はリクエスト/ストリームの終了をログに出力します。
+func (l *Logger) logEnd(ctx context.Context, req connect.AnyRequest, startTime time.Time, err error) {
+	duration := time.Since(startTime)
+	logFields := []slog.Attr{
+		slog.String("procedure", req.Spec().Procedure),
+		slog.String("code", connect.CodeOf(err).String()),
+		slog.Duration("duration", duration),
+	}
+
+	if err != nil {
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			logFields = append(logFields, slog.String("code", connectErr.Code().String()))
+		}
+		logFields = append(logFields, slog.String("error", err.Error()))
+		l.logger.LogAttrs(ctx, slog.LevelError, "finished with error", logFields...)
+	} else {
+		l.logger.LogAttrs(ctx, slog.LevelInfo, "finished", logFields...)
+	}
+}
+
+// file: interceptor/logger.go (続き)
+
+// NewUnaryInterceptor は共通ロガーを使ったUnaryインターセプターを返します。
+func (l *Logger) NewUnaryInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			startTime := time.Now()
+
+			l.logStart(ctx, req)
+			res, err := next(ctx, req)
+			l.logEnd(ctx, req, startTime, err)
+
+			return res, err
+		}
+	}
+}

--- a/internal/log.go
+++ b/internal/log.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"time"
 
@@ -41,10 +40,6 @@ func (l *Logger) logEnd(ctx context.Context, req connect.AnyRequest, startTime t
 	}
 
 	if err != nil {
-		var connectErr *connect.Error
-		if errors.As(err, &connectErr) {
-			logFields = append(logFields, slog.String("code", connectErr.Code().String()))
-		}
 		logFields = append(logFields, slog.String("error", err.Error()))
 		l.logger.LogAttrs(ctx, slog.LevelError, "finished with error", logFields...)
 	} else {

--- a/internal/log.go
+++ b/internal/log.go
@@ -47,8 +47,6 @@ func (l *Logger) logEnd(ctx context.Context, req connect.AnyRequest, startTime t
 	}
 }
 
-// file: interceptor/logger.go (続き)
-
 // NewUnaryInterceptor は共通ロガーを使ったUnaryインターセプターを返します。
 func (l *Logger) NewUnaryInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {

--- a/internal/log.go
+++ b/internal/log.go
@@ -23,7 +23,7 @@ func (l *Logger) logStart(ctx context.Context, req connect.AnyRequest) {
 		ctx,
 		slog.LevelInfo,
 		"start processing request",
-slog.String("procedure", req.Spec().Procedure),
+		slog.String("procedure", req.Spec().Procedure),
 		slog.String("user-agent", req.Header().Get("User-Agent")),
 		slog.String("http_method", req.HTTPMethod()),
 		slog.String("peer", req.Peer().Addr),


### PR DESCRIPTION
This pull request introduces a structured logging interceptor for Connect-Go, refactors the server to use dependency injection for logging, and updates documentation and tests to reflect these changes. The main improvement is the addition of a reusable logging interceptor that cleanly separates cross-cutting concerns from business logic, making the system more maintainable and extensible.

### Logging Interceptor Implementation

* Added a new `Logger` type and logging interceptor in `internal/log.go`, providing request lifecycle logging for Connect-Go services. This interceptor logs request start, end, errors, and metadata, and is designed for easy reuse and extension.

* Refactored `cmd/server/main.go` to inject a `*slog.Logger` into `ChatServer`, replacing direct calls to `slog.Info` with the injected logger. The server now applies the logging interceptor to all unary RPCs. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR17) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR36-L47) [[3]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL78-R92) [[4]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL96-R123)

### Documentation Updates

* Expanded the `README.md` to include a comprehensive section on Connect-Go interceptors, their benefits, implementation details, chaining, and comparison with traditional HTTP middleware. Example code and log output are provided for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L319-R467) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R482-R491)

### Test Refactoring

* Updated all tests in `cmd/server/main_test.go` to instantiate `ChatServer` with a logger, ensuring the new constructor and logging features are covered by tests. Added assertions for logger presence in the server. [[1]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eR5-R6) [[2]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eL14-R29) [[3]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eL89-R95) [[4]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eL106-R113) [[5]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eL126-R134) [[6]](diffhunk://#diff-4a9e675d169ae3a98afd4b7d94f79a3a595ac0680da6730f28f5f6e1c8070d1eL146-R155)