### PR TITLE
test: add forward compatibility test for ChatServer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,7 @@ func init() {
 type ChatServer struct {
 	validator protovalidate.Validator
 	logger    *slog.Logger
+	chatv1.UnimplementedChatServiceServer
 }
 
 func NewChatServer(logger *slog.Logger) (*ChatServer, error) {


### PR DESCRIPTION
This pull request improves the forward compatibility of the `ChatServer` implementation by embedding the `UnimplementedChatServiceServer` and adds a corresponding test to ensure future service changes do not break compilation. The main changes are grouped into server implementation and testing enhancements:

**Server implementation:**

* Embedded `chatv1.UnimplementedChatServiceServer` in the `ChatServer` struct to ensure that any future additions to the gRPC service definition will automatically return "Unimplemented" responses, preventing compilation errors.

**Testing enhancements:**

* Added a new test `TestChatServer_ForwardCompatibility` to verify that the server embeds `UnimplementedChatServiceServer`, ensuring forward compatibility and confirming that existing functionality remains unaffected.